### PR TITLE
changed to_port of ingress egress to "0"

### DIFF
--- a/networking.tf
+++ b/networking.tf
@@ -111,7 +111,7 @@ resource "aws_security_group" "mtc_sg_pub" {
 resource "aws_security_group_rule" "ingress_all" {
   type              = "ingress" # 
   from_port         = 0         # starting port for port access
-  to_port           = 65535     # Ending port for port access
+  to_port           = 0     # Ending port for port access
   protocol          = "-1"      # Specifies any protocol.Includes UDP/TCP/ICMP
   cidr_blocks       = [var.access_ip]
   security_group_id = aws_security_group.mtc_sg_pub.id
@@ -122,7 +122,7 @@ resource "aws_security_group_rule" "ingress_all" {
 resource "aws_security_group_rule" "egress_all" {
   type              = "egress" # 
   from_port         = 0        # starting port for port access
-  to_port           = 65535    # Ending port for port access
+  to_port           = 0    # Ending port for port access
   protocol          = "-1"     # Specifies any protocol.Includes UDP/TCP/ICMP
   cidr_blocks       = ["0.0.0.0/0"]
   security_group_id = aws_security_group.mtc_sg_pub.id


### PR DESCRIPTION
╷
│ Error: error updating Security Group (sg-09daa0eaca796184e): from_port (0) and to_port (65535) must both be 0 to use the 'ALL' "-1" protocol! │
│   with aws_security_group.my_sg_1,
│   on main.tf line 55, in resource "aws_security_group" "my_sg_1":
│   55: resource "aws_security_group" "my_sg_1" {
│